### PR TITLE
Accommodate invocation just with an array from TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,9 @@ type WeightedOptions = {
   total?: number
 };
 //
+type SimpleSelectArrFunction =
+  <S>(
+    set: Readonly<Array<S>>) => S;
 type SelectArrFunction =
   <S>(
     set: Readonly<Array<S>>,
@@ -13,7 +16,7 @@ type SelectObjFunction =
   <O, K extends keyof O>(
     obj: Readonly<O>,
     options?: WeightedOptions) => K;
-type SelectFunction = SelectArrFunction & SelectObjFunction;
+type SelectFunction = SimpleSelectArrFunction & SelectArrFunction & SelectObjFunction;
 //
 type WeightedFunction = SelectFunction & {
   select: SelectFunction,


### PR DESCRIPTION
Without this for plain `weighted(["a","b","c"])` TypeScript would match `SelectObjFunction` and not consider the return value to be a string as intended, but a string or a symbol, as it would conclude from the keys of what it would consider an object, even though us people clearly see an array of strings.

Ran fine for us even without, but this commit makes TypeScript stop saying a symbol could be returned.

Never had that simple use case before, hence this detail hadn't been handled in the earlier version.  Here it is.